### PR TITLE
PatrionDigital/issue3

### DIFF
--- a/app/components/game/GameEngine.tsx
+++ b/app/components/game/GameEngine.tsx
@@ -4,6 +4,7 @@ import GameTimer from "./GameTimer";
 import ScoreCounter from "./ScoreCounter";
 import GameFeedback from "./GameFeedback";
 import { Button } from "../DemoComponents";
+import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
 // 1. Game States
 export enum GameState {
@@ -18,7 +19,11 @@ type GameAction =
   | { type: "TIMER_TICK" }
   | { type: "END_GAME" }
   | { type: "RESET_GAME" }
-  | { type: "END_FEEDBACK" };
+  | { type: "END_FEEDBACK" }
+  | { type: "SET_DEVICE_INFO"; payload: Record<string, any> }
+  | { type: "SET_DEVICE_FINGERPRINT"; payload: string }
+  | { type: "SET_PERFORMANCE_SCORE"; payload: number }
+  | { type: "SET_INTEGRITY_HASH"; payload: string };
 
 
 interface GameStateModel {
@@ -27,6 +32,13 @@ interface GameStateModel {
   timeLeft: number;
   taps: number[];
   feedback: boolean;
+
+  // --- Anti-cheat fields ---
+  tapTimestamps: number[]; // High-precision tap timestamps
+  deviceInfo?: Record<string, any>; // Device info snapshot
+  deviceFingerprint?: string; // Device fingerprint string
+  performanceScore?: number; // Device performance benchmark (ms)
+  integrityHash?: string; // Session integrity hash
 }
 
 const GAME_DURATION = 25; // seconds
@@ -40,6 +52,11 @@ function gameReducer(state: GameStateModel, action: GameAction): GameStateModel 
         timeLeft: GAME_DURATION,
         taps: [],
         feedback: false,
+        tapTimestamps: [],
+        deviceInfo: undefined, // TODO: Populate at game start
+        deviceFingerprint: undefined, // TODO: Populate at game start
+        performanceScore: undefined, // TODO: Populate at game start
+        integrityHash: undefined, // TODO: Generate at game end
       };
     case "TAP":
       if (state.gameState !== GameState.Running) return state;
@@ -47,6 +64,7 @@ function gameReducer(state: GameStateModel, action: GameAction): GameStateModel 
         ...state,
         score: state.score + 1,
         taps: [...state.taps, action.timestamp],
+        tapTimestamps: [...(state.tapTimestamps || []), typeof performance !== 'undefined' ? performance.now() : Date.now()],
         feedback: true,
       };
     case "TIMER_TICK":
@@ -63,9 +81,22 @@ function gameReducer(state: GameStateModel, action: GameAction): GameStateModel 
         timeLeft: GAME_DURATION,
         taps: [],
         feedback: false,
+        tapTimestamps: [],
+        deviceInfo: undefined,
+        deviceFingerprint: undefined,
+        performanceScore: undefined,
+        integrityHash: undefined,
       };
     case "END_FEEDBACK":
       return { ...state, feedback: false };
+    case "SET_DEVICE_INFO":
+      return { ...state, deviceInfo: action.payload };
+    case "SET_DEVICE_FINGERPRINT":
+      return { ...state, deviceFingerprint: action.payload };
+    case "SET_PERFORMANCE_SCORE":
+      return { ...state, performanceScore: action.payload };
+    case "SET_INTEGRITY_HASH":
+      return { ...state, integrityHash: action.payload };
     default:
       return state;
   }
@@ -78,7 +109,98 @@ export const GameEngine: React.FC<{ initialGameState?: GameState }> = ({ initial
     timeLeft: GAME_DURATION,
     taps: [],
     feedback: false,
+    tapTimestamps: [],
+    deviceInfo: undefined,
+    deviceFingerprint: undefined,
+    performanceScore: undefined,
+    integrityHash: undefined,
   });
+
+  // --- Anti-cheat: Device fingerprinting and info ---
+  useEffect(() => {
+    if (state.gameState === GameState.Running) {
+      // Device info (only set once)
+      if (!state.deviceInfo) {
+        const deviceInfo = {
+          userAgent: navigator.userAgent,
+          platform: navigator.platform,
+          language: navigator.language,
+          screen: {
+            width: window.screen.width,
+            height: window.screen.height,
+            colorDepth: window.screen.colorDepth,
+            pixelRatio: window.devicePixelRatio,
+          },
+          memory: (navigator as any).deviceMemory || undefined,
+          hardwareConcurrency: (navigator as any).hardwareConcurrency || undefined,
+          touchSupport: 'ontouchstart' in window || navigator.maxTouchPoints > 0,
+        };
+        dispatch({ type: 'SET_DEVICE_INFO', payload: deviceInfo } as any);
+      }
+      // Fingerprint (only set once)
+      if (!state.deviceFingerprint) {
+        FingerprintJS.load()
+          .then(fp => fp.get())
+          .then(result => {
+            dispatch({ type: 'SET_DEVICE_FINGERPRINT', payload: result.visitorId } as any);
+          })
+          .catch(() => {
+            dispatch({ type: 'SET_DEVICE_FINGERPRINT', payload: 'unavailable' } as any);
+          });
+      }
+      // Performance benchmark (only set once)
+      if (!state.performanceScore) {
+        // Micro-benchmark: time for 1 million empty iterations
+        const iterations = 1_000_000;
+        const t0 = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        let x = 0;
+        for (let i = 0; i < iterations; i++) {
+          x++;
+        }
+        const t1 = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const elapsed = t1 - t0;
+        dispatch({ type: 'SET_PERFORMANCE_SCORE', payload: elapsed } as any);
+      }
+    }
+  }, [state.gameState, state.deviceFingerprint, state.deviceInfo, state.performanceScore]);
+
+  // --- Anti-cheat: Integrity hash generation at game end ---
+  useEffect(() => {
+    async function generateIntegrityHash() {
+      // Canonicalize session data
+      const sessionData = {
+        tapTimestamps: state.tapTimestamps,
+        deviceInfo: state.deviceInfo,
+        deviceFingerprint: state.deviceFingerprint,
+        performanceScore: state.performanceScore,
+        score: state.score,
+        sessionEnd: Date.now(),
+      };
+      const json = JSON.stringify(sessionData);
+      // Use Web Crypto API for SHA-256
+      const encoder = new TextEncoder();
+      const data = encoder.encode(json);
+      try {
+        const hashBuffer = await (window.crypto.subtle || (window as any).crypto.subtle).digest('SHA-256', data);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+        dispatch({ type: 'SET_INTEGRITY_HASH', payload: hashHex } as any);
+      } catch {
+        dispatch({ type: 'SET_INTEGRITY_HASH', payload: 'unavailable' } as any);
+      }
+    }
+    if (
+      state.gameState === GameState.Finished &&
+      state.tapTimestamps &&
+      state.tapTimestamps.length > 0 &&
+      state.deviceInfo &&
+      state.deviceFingerprint &&
+      state.performanceScore &&
+      !state.integrityHash
+    ) {
+      generateIntegrityHash();
+    }
+  }, [state.gameState, state.tapTimestamps, state.deviceInfo, state.deviceFingerprint, state.performanceScore, state.score, state.integrityHash]);
 
   // Timer interval ref
   const timerRef = useRef<NodeJS.Timeout | null>(null);

--- a/instructions/anti-cheat-client-plan.md
+++ b/instructions/anti-cheat-client-plan.md
@@ -1,0 +1,108 @@
+# KissMint DASH: Anti-Cheat (Client-Side) Implementation Plan
+
+## Objectives
+- Prevent and detect automated/inauthentic play.
+- Provide robust gameplay data for server-side verification.
+- Deter multi-accounting and device spoofing.
+
+---
+
+## 1. Tap Pattern Tracking
+
+### 1.1. Collect High-Precision Tap Timestamps
+- Use `performance.now()` for millisecond precision.
+- Store each tap’s timestamp in an array (`tapTimestamps`).
+
+### 1.2. Calculate Tap Intervals
+- On game end, compute intervals between taps.
+- Analyze for:
+  - **Average interval** (flag if < physical human minimum, e.g., 30ms)
+  - **Variance** (flag if too consistent, i.e., robotic)
+  - **Distribution** (for further analysis)
+
+---
+
+## 2. Device Fingerprinting
+
+### 2.1. Device Info Collection
+- Collect non-PII device info:
+  - `navigator.userAgent`, `navigator.platform`, `navigator.language`
+  - Screen size, color depth, pixel ratio
+  - Optional: memory, hardware concurrency, touch support
+
+### 2.2. Generate Device Fingerprint
+- Use a lightweight library ([@fingerprintjs/fingerprintjs](https://github.com/fingerprintjs/fingerprintjs)) or a custom hash of device info.
+- Store fingerprint at game start.
+
+---
+
+## 3. Performance Benchmarking
+
+### 3.1. Benchmark Device Capabilities
+- At game start, run a micro-benchmark (e.g., measure time for 1000 empty loops).
+- Store result as `devicePerformanceScore`.
+- Use this to flag scores that exceed device’s physical capabilities.
+
+---
+
+## 4. Integrity Hash Generation
+
+### 4.1. Gather All Session Data
+- Tap timestamps
+- Device fingerprint & info
+- Performance benchmark
+- Game session start/end time
+- Final score
+
+### 4.2. Generate Hash
+- Use `crypto.subtle.digest('SHA-256', ...)` (Web Crypto API) or a small SHA256 npm package.
+- Hash a canonical JSON string of the above data.
+- Store as `integrityHash` in the submission payload.
+
+---
+
+## 5. Client-Side Verification Before Submission
+- Run basic checks before submission:
+  - Tap intervals/variance within human range
+  - Score not exceeding device benchmark
+- If failed, warn user or flag submission.
+
+---
+
+## 6. Data Submission
+- Submit all anti-cheat data with the score:
+  - `tapTimestamps`, `deviceInfo`, `deviceFingerprint`, `performanceScore`, `integrityHash`, `finalScore`, etc.
+
+---
+
+## 7. Developer Notes & Security
+- **Do not expose secret keys** client-side; server should add a secret for final hash verification.
+- All anti-cheat logic should be as tamper-resistant as possible, but assume client can be reverse-engineered.
+- Server must perform its own verification and not trust client-side checks alone.
+
+---
+
+## 8. Implementation Steps
+
+1. **Update Game State & Reducer**
+   - Add `tapTimestamps`, `deviceInfo`, `deviceFingerprint`, `performanceScore`, `integrityHash` to state.
+2. **Integrate Device Fingerprinting**
+   - Add async fingerprint generation at game start.
+3. **Add Performance Benchmark**
+   - Run benchmark at game start and store result.
+4. **Track Taps**
+   - On each tap, push timestamp to state.
+5. **On Game End**
+   - Calculate intervals, variance, and generate hash.
+   - Run client-side verification.
+6. **Submit Data**
+   - Send all anti-cheat data with score to backend.
+7. **(Optional) UI Feedback**
+   - Show warnings if suspicious behavior is detected before submission.
+
+---
+
+## References
+- [@fingerprintjs/fingerprintjs](https://github.com/fingerprintjs/fingerprintjs)
+- [Web Crypto API - SubtleCrypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest)
+- Internal docs: ai-rules.md, backend-structure.md, frontend-guidelines.md, application-flow.md, kissmint-dev-plan.md

--- a/instructions/detailed-workplan.md
+++ b/instructions/detailed-workplan.md
@@ -59,7 +59,7 @@
 - Implement tap detection with <50ms latency.
 - Add real-time feedback (visual/audio) per tap.
 
-- [ ] **4.2. Game State & Flow**
+- [x] **4.2. Game State & Flow**
 
 [(Issue 2)](https://github.com/PatrionDigital/kissmintdash/issues/2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@coinbase/onchainkit": "latest",
         "@farcaster/frame-sdk": "^0.0.35",
+        "@fingerprintjs/fingerprintjs": "^4.6.2",
         "@tanstack/react-query": "^5",
         "@upstash/redis": "^1.34.4",
         "next": "^14.2.15",
@@ -1196,6 +1197,15 @@
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
         "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@fingerprintjs/fingerprintjs": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-4.6.2.tgz",
+      "integrity": "sha512-g8mXuqcFKbgH2CZKwPfVtsUJDHyvcgIABQI7Y0tzWEFXpGxJaXuAuzlifT2oTakjDBLTK4Gaa9/5PERDhqUjtw==",
+      "license": "BUSL-1.1",
+      "dependencies": {
+        "tslib": "^2.4.1"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@coinbase/onchainkit": "latest",
     "@farcaster/frame-sdk": "^0.0.35",
+    "@fingerprintjs/fingerprintjs": "^4.6.2",
     "@tanstack/react-query": "^5",
     "@upstash/redis": "^1.34.4",
     "next": "^14.2.15",


### PR DESCRIPTION
Pull Request: Client-Side Anti-Cheat Integration for MiniKit (Fixes Issue #3)
Related Issue:
Fixes Issue #3

Overview
This PR introduces a robust, client-only anti-cheat system for the MiniKit-based game engine, addressing the requirements and design outlined in the detailed work plan. It ensures compatibility with the MiniKitProvider and avoids any conflicts with the SDK.

Key Changes
FingerprintJS Integration:
Added @fingerprintjs/fingerprintjs as a dependency.
On game start, collects a unique browser/device fingerprint for each session.
Device Information Collection:
Gathers user agent, platform, language, screen details, memory, hardware concurrency, and touch support.
Performance Benchmark:
Runs a micro-benchmark on the client to record device performance characteristics.
Session Integrity Hash:
At game end, generates a SHA-256 integrity hash of all anti-cheat/session data using the Web Crypto API.
All data is stored in local React state for future backend validation.
MiniKit Compatibility:
All anti-cheat logic is strictly client-side and only runs after MiniKitProvider is mounted.
No global side effects or context conflicts with MiniKit SDK.
How it Works
On Game Start:
Collect device info and browser fingerprint.
Benchmark performance.
On Game End:
Canonicalize session data and generate a session integrity hash.
No Backend Dependency:
All anti-cheat/session data is prepared for future backend validation, but no server is required at this stage.
Testing
Verified that the anti-cheat logic runs only on the client and does not interfere with MiniKitProvider.
Confirmed that all session data and hashes are generated and stored in local state.
Notes
This PR lays the foundation for robust anti-cheat and session validation. When a backend is added, all anti-cheat/session data can be sent for server-side verification.
See the detailed work plan for further context and next steps.